### PR TITLE
PL-1742 Proposed new PR template for all Portals repos (including SureUI)

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,3 @@
-
 <!-- Please complete each section below the # lines, as applicable -->  
 
 <!-- Simple description, 1-2 lines -->  
@@ -12,7 +11,7 @@
 # Jira Link(s)
 
 
-<!-- Add short screen recordings or screenshots -->  
+<!-- Add short screen recordings or screen shots -->  
 # Demo / Screen Shot (as applicable)
 
 
@@ -24,16 +23,16 @@ Please consider every checkbox -- if it's **done OR not applicable**, check the 
 - [ ] Assigned corresponding reviewers or notified in Slack
 - [ ] Updated README
 - [ ] Updated library CHANGELOG with
-    - [ ] Environment Variables added/changed
-    - [ ] Secrets added/changed
-    - [ ] Feature Flags added/changed
+  - [ ] Environment Variables added/changed
+  - [ ] Secrets added/changed
+  - [ ] Feature Flags added/changed
 - [ ] Updated [Test data](https://github.com/sureifylabs/coreconnect-sdk/tree/main/library/packages/sdk/wild/src/db/testData) and/or Demo data
 - [ ] Updated Postman collection for any API additions/changes
-- [ ] For CC-SDK or SureUI library changes, added a subtask for updating EmptyCo
+- [ ] For CC-SDK or SureUI library changes, added a Jira subtask for updating EmptyCo
 
 ## Author Notes
 - If the PR is not yet ready to be reviewed [Create a Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft) or add the Do Not Merge label
 - If a reviewer comments on something that could have been caught by a lint rule, either add that rule to the linter, or create a Jira ticket to add it.
 
 ## Reviewer Notes
-If any PR doesn't meet the above standards, please feel free to reject the PR. :evil-laugh:
+If the PR doesn't meet the above standards, please feel free to reject it. 👎 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,22 +1,12 @@
-<!-- Please complete each section below the # lines, as applicable -->  
+# Description (_Why_ we're making the change)
 
-<!-- Simple description, 1-2 lines -->  
-# Description (**Why** we're making the change)
-
-
-<!-- Describe what changed -->  
-# What's changed? (summarize the code change)
-
+# What's changed? (Summary of code change)
 
 # Jira Link(s)
 
-
-<!-- Add short screen recordings or screen shots -->  
 # Demo / Screen Shot (as applicable)
 
-
-<!-- To complete the checklist, replace [ ] with [x]  
-     or click the checkboxes after PR creation -->  
+<!-- To complete the checklist, replace [ ] with [x]  or click the checkboxes after PR creation -->  
 # PR Author Checklist
 Please consider every checkbox -- if it's **done OR not applicable**, check the box!
 - [ ] Unit tests added/updated
@@ -35,4 +25,4 @@ Please consider every checkbox -- if it's **done OR not applicable**, check the 
 - If a reviewer comments on something that could have been caught by a lint rule, either add that rule to the linter, or create a Jira ticket to add it.
 
 ## Reviewer Notes
-If the PR doesn't meet the above standards, please feel free to reject it. 👎 
+If the PR doesn't meet the above standards 👎 please add a review to "Request changes". 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,21 +6,23 @@
 
 # Demo / Screen Shot (as applicable)
 
-<!-- To complete the checklist, replace [ ] with [x]  or click the checkboxes after PR creation -->  
+<!-- To complete the checklist, replace [ ] with [x]  OR click the checkboxes after PR creation -->  
 # PR Author Checklist
 Please consider every checkbox -- if it's **done OR not applicable**, check the box!
-- [ ] Unit tests added/updated
-- [ ] Assigned corresponding reviewers or notified in Slack
+- [ ] Added/Updated Unit tests
 - [ ] Updated README
 - [ ] Updated library CHANGELOG with
+  - [ ] Breaking changes
   - [ ] Environment Variables added/changed
   - [ ] Secrets added/changed
   - [ ] Feature Flags added/changed
 - [ ] Updated [Test data](https://github.com/sureifylabs/coreconnect-sdk/tree/main/library/packages/sdk/wild/src/db/testData) and/or Demo data
-- [ ] Updated Postman collection for any API additions/changes
+- [ ] Added/Updated API service tests
+- [ ] Updated Postman collection for any product-level API additions/changes
 - [ ] For CC-SDK or SureUI library changes, added a Jira subtask for updating EmptyCo
 
 ## Author Notes
+- EVERY checkbox above should be checked off (as done or n/a) before reviews are requested
 - If the PR is not yet ready to be reviewed [Create a Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft) or add the Do Not Merge label
 - If a reviewer comments on something that could have been caught by a lint rule, either add that rule to the linter, or create a Jira ticket to add it.
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,35 +1,38 @@
-<!-- Please complete each section below the # lines, as applicable -->
 
-<!-- Simple description, 1-2 lines -->
-# Description
+<!-- Please complete each section below the # lines, as applicable -->  
+
+<!-- Simple description, 1-2 lines -->  
+# Description (**Why** we're making the change)
 
 
-<!-- Describe what changed -->
-# What's new?
+<!-- Describe what changed -->  
+# What's changed? (summarize the code change)
 
 
 # Jira Link(s)
 
 
-<!-- Add short screen recordings or screen shots -->
+<!-- Add short screen recordings or screenshots -->  
 # Demo / Screen Shot (as applicable)
 
 
-
-<!-- To complete the checklist, replace [ ] with [x]
-     or click the checkboxes after PR creation -->
+<!-- To complete the checklist, replace [ ] with [x]  
+     or click the checkboxes after PR creation -->  
 # PR Author Checklist
-- [ ] Unit tests added, already exist, or are not applicable
-- [ ] Added necessary label(s)
-- [ ] Assigned corresponding reviewer(s)
-- [ ] Updated README / CHANGELOG (if applicable)
+Please consider every checkbox -- if it's **done OR not applicable**, check the box!
+- [ ] Unit tests added/updated
+- [ ] Assigned corresponding reviewers or notified in Slack
+- [ ] Updated README
+- [ ] Updated library CHANGELOG with
+    - [ ] Environment Variables added/changed
+    - [ ] Secrets added/changed
+    - [ ] Feature Flags added/changed
+- [ ] Updated [Test data](https://github.com/sureifylabs/coreconnect-sdk/tree/main/library/packages/sdk/wild/src/db/testData) and/or Demo data
+- [ ] Updated Postman collection for any API additions/changes
+- [ ] For CC-SDK or SureUI library changes, added a subtask for updating EmptyCo
 
 ## Author Notes
-- Add label for least one of:
-    - Ready for Review
-    - WIP
-    - don't merge
-- If the PR is not yet ready to be assigned to reviewers [Create a Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft)
+- If the PR is not yet ready to be reviewed [Create a Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft) or add the Do Not Merge label
 - If a reviewer comments on something that could have been caught by a lint rule, either add that rule to the linter, or create a Jira ticket to add it.
 
 ## Reviewer Notes


### PR DESCRIPTION
# Description (_Why_ we're making the change)  
  We need to expand the scope of what's expected with a PR review and clarify some of the prompts.

# What's changed? (Summary of code change)  
  Update default PR template

# Jira Link(s)  
  https://sureify.atlassian.net/browse/PL-1742

# Demo / Screen Shot (as applicable)  
  n/a

<!-- To complete the checklist, replace [ ] with [x]  or click the checkboxes after PR creation -->  
# PR Author Checklist  
Please consider every checkbox -- if it's **done OR not applicable**, check the box!  
- [x] Unit tests added/updated  
- [x] Assigned corresponding reviewers or notified in Slack  
- [x] Updated README
- [x] Updated library CHANGELOG with
	- [x] Environment Variables added/changed
	- [x] Secrets added/changed
	- [x] Feature Flags added/changed
- [x] Updated [Test data](https://github.com/sureifylabs/coreconnect-sdk/tree/main/library/packages/sdk/wild/src/db/testData) and/or Demo data  
- [x] Updated Postman collection for any API additions/changes  
- [x] For CC-SDK or SureUI library changes, added a Jira subtask for updating EmptyCo  
  
## Author Notes  
- If the PR is not yet ready to be reviewed [Create a Draft PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft) or add the Do Not Merge label  
- If a reviewer comments on something that could have been caught by a lint rule, either add that rule to the linter, or create a Jira ticket to add it.  
  
## Reviewer Notes  
If the PR doesn't meet the above standards 👎 please add a review to "Request changes". 